### PR TITLE
Add to contrib after loading 'sly.

### DIFF
--- a/sly-macrostep-autoloads.el
+++ b/sly-macrostep-autoloads.el
@@ -9,7 +9,8 @@
 ;;;### (autoloads nil "sly-macrostep" "sly-macrostep.el" (0 0 0 0))
 ;;; Generated autoloads from sly-macrostep.el
 
-(add-to-list 'sly-contribs 'sly-macrostep 'append)
+(with-eval-after-load 'sly
+  (add-to-list 'sly-contribs 'sly-macrostep 'append))
 
 (if (fboundp 'register-definition-prefixes) (register-definition-prefixes "sly-macrostep" '("sly-macrostep")))
 

--- a/sly-macrostep.el
+++ b/sly-macrostep.el
@@ -140,7 +140,8 @@
 
 ;;; Automatically add ourselves to `sly-contribs' when this file is loaded
 ;;;###autoload
-(add-to-list 'sly-contribs 'sly-macrostep 'append)
+(with-eval-after-load 'sly
+  (add-to-list 'sly-contribs 'sly-macrostep 'append))
 
 (provide 'sly-macrostep)
 ;;; sly-macrostep.el ends here


### PR DESCRIPTION
Else the load would fail if the package happens to be loaded before SLY.